### PR TITLE
Trim version string due to Windows `echo`

### DIFF
--- a/rungo.go
+++ b/rungo.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
@@ -54,7 +55,7 @@ func findVersionFile() string {
 			_ = versionFile.Close()
 			if version != "" {
 				log.Debugf("Using version specification from %v", versionFileName)
-				return version
+				return strings.TrimSpace(version)
 			}
 		}
 


### PR DESCRIPTION
The windows `echo` command produces a trailing space with this command:

```
echo 1.2.3 > .go-version
```

Trim the string so users don't have to remove the space between `3` and `>`.